### PR TITLE
Catch interrupt signals in subprocess

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -54,7 +54,7 @@ func exe(c *cli.Context, step string) {
 	cmd.Stderr = os.Stderr
 
 	ch := make(chan os.Signal)
-	signal.Notify(ch, syscall.SIGINT, syscall.SIGKILL, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGCHLD)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 	go func() {
 		<-ch
 		os.Exit(0)


### PR DESCRIPTION
Ex: Ctrl + C in a step like `docker exec -it my_container /bin/bash`